### PR TITLE
fix: add justfile

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
           enable-cache: true
 
       - name: Install the project
-        run: uv sync --locked
+        run: uv sync
 
       - name: Cache pre-commit
         uses: actions/cache@v4

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,0 +1,5 @@
+rule_settings:
+  disable:
+    - use-named-expression
+    - reintroduce-else
+    - swap-if-else-branches

--- a/justfile
+++ b/justfile
@@ -1,0 +1,10 @@
+default:
+    just --list
+
+build tag:
+    docker buildx build \
+    --platform linux/amd64,linux/arm64 \
+    -t ghcr.io/julienpillaud/levindorge:{{ tag }} \
+
+push tag:
+    docker push ghcr.io/julienpillaud/levindorge:{{ tag }}


### PR DESCRIPTION
## Summary by Sourcery

Update lint CI command, introduce a justfile for streamlined Docker build and push operations, and configure Sourcery rule settings.

Build:
- Add a justfile with default, build tag, and push tag recipes for multi-platform Docker image workflows.

CI:
- Remove the --locked flag from uv sync in the lint workflow.

Chores:
- Add .sourcery.yaml to disable specific automated refactoring rules.